### PR TITLE
fix: updating rpm

### DIFF
--- a/hardened-chromium-subresource-filter.spec
+++ b/hardened-chromium-subresource-filter.spec
@@ -126,9 +126,6 @@ install -m 0755 %{SOURCE3} "$SCRIPT_DIR/install_filter.sh"
 echo "%{release}" > $INSTALL_DIR/hardened-chromium-blocklist-version.txt
 chmod a+r $INSTALL_DIR/hardened-chromium-blocklist-version.txt
 
-%postun
-rmdir %{_sysconfdir}/chromium/filter
-
 %files
 %{_sysconfdir}/chromium/filter/hardened-chromium-blocklist
 %{_sysconfdir}/chromium/filter/hardened-chromium-blocklist-version.txt

--- a/hardened-chromium-subresource-filter.spec
+++ b/hardened-chromium-subresource-filter.spec
@@ -127,7 +127,7 @@ echo "%{release}" > $INSTALL_DIR/hardened-chromium-blocklist-version.txt
 chmod a+r $INSTALL_DIR/hardened-chromium-blocklist-version.txt
 
 %postun
-rm -r %{_sysconfdir}/chromium/filter
+rmdir %{_sysconfdir}/chromium/filter
 
 %files
 %{_sysconfdir}/chromium/filter/hardened-chromium-blocklist


### PR DESCRIPTION
When upgrading the RPM, postun will clear the directory in its entirety. This drops postun, it means there will be an empty directory in /etc/chromium but that isn't a big deal.