### PR TITLE
chore: Revert "chore: force use_siso=true"

### DIFF
--- a/trivalent-subresource-filter.spec
+++ b/trivalent-subresource-filter.spec
@@ -127,7 +127,6 @@ CHROMIUM_GN_DEFINES+=' system_libdir="%{_lib}"'
 CHROMIUM_GN_DEFINES+=' is_clang=true'
 CHROMIUM_GN_DEFINES+=' use_sysroot=false'
 CHROMIUM_GN_DEFINES+=' treat_warnings_as_errors=false'
-CHROMIUM_GN_DEFINES+=' use_siso=true'
 export CHROMIUM_GN_DEFINES
 
 mkdir -p %{chromebuilddir}


### PR DESCRIPTION
Reverts secureblue/trivalent-subresource-filter#66

Shouldnt be necessary