### PR TITLE
chore: use hour long release intervals

### DIFF
--- a/trivalent-subresource-filter.spec
+++ b/trivalent-subresource-filter.spec
@@ -45,8 +45,8 @@ Summary:   Subresource filter for %{chromium_name}
   -- This will dynamically set the version based on chromium's latest stable release channel
   print("Version: "..version_tag.."\n")
 
-  -- This will automatically increment the release every ~16 minutes
-  print("Release: "..(os.time() // 1000).."\n")
+  -- This will automatically increment the release every ~1 hour
+  print("Release: "..(os.time() // 4000).."\n")
 }
 
 Source0: chromium-%{version}-clean.tar.xz


### PR DESCRIPTION
This avoids a race condition between the srpm and rpm release values