### PR TITLE
fix: sysroot dep

### DIFF
--- a/150-remove-sysroot-dep.patch
+++ b/150-remove-sysroot-dep.patch
@@ -1,0 +1,25 @@
+Copyright 2026 The Trivalent Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is
+distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and limitations under the License.
+---
+diff --git a/build/modules/BUILD.gn b/build/modules/BUILD.gn
+index 02b02e7e5c..976618d10a 100644
+--- a/build/modules/BUILD.gn
++++ b/build/modules/BUILD.gn
+@@ -223,7 +223,7 @@ if (use_unified_system_module) {
+         # otherwise.
+         "--append-module=std.new:export new_h\\nexport vcruntime_exception",
+       ]
+-    } else {
++    } else if (use_sysroot) {
+       # We need to pass the sysroot in so that it can scan it to generate a
+       # modulemap for the sysroot headers.
+       args += [

--- a/trivalent-subresource-filter.spec
+++ b/trivalent-subresource-filter.spec
@@ -71,6 +71,7 @@ BuildRequires: pipewire-devel
 BuildRequires: git-core
 
 Patch0: use-cwd-for-gclient-path.patch
+Patch1: 150-remove-sysroot-dep.patch
 
 %description
 Filter used by %{chromium_name} to provide content blocking.
@@ -79,6 +80,7 @@ Filter used by %{chromium_name} to provide content blocking.
 %setup -q -n chromium-%{version}
 
 %patch -P0 -p1 -b .use-cwd-for-gclient-path
+%patch -P1 -p1 -b .150-remove-sysroot-dep
 
 %build
 FLAGS=' -Wno-deprecated-declarations -Wno-unknown-warning-option -Wno-unused-command-line-argument'


### PR DESCRIPTION
Fixes:

```
+ gn --script-executable=/usr/bin/python3 gen '--args= system_libdir="lib64" is_clang=true use_sysroot=false treat_warnings_as_errors=false' out/Release
ERROR at //build/modules/BUILD.gn:231:21: Empty directory path.
        rebase_path(sysroot, root_build_dir),
                    ^------
You can't use empty strings as directories.
See //build/modules/BUILD.gn:231:21: The value that caused the error.
        rebase_path(sysroot, root_build_dir),
                    ^
See //BUILD.gn:100:7: which caused the file to be included.
      "//build/modules",
      ^----------------
error: Bad exit status from /var/tmp/rpm-tmp.4iZUMp (%build)

RPM build warnings:
```
https://download.copr.fedorainfracloud.org/results/secureblue/packages/fedora-44-x86_64/10686990-trivalent-subresource-filter/builder-live.log.gz