### PR TITLE
build: auto-generate changelog entries from copr builds

### DIFF
--- a/copr_script.sh
+++ b/copr_script.sh
@@ -62,3 +62,8 @@ for url in "${LIST_SOURCES[@]}"; do
     wget "$url" -O "filter-$counter.txt"
     counter=$((counter+1))
 done
+
+# Generate changelog from 50 most recent successful Copr builds
+curl -fLsS --retry 3 "https://copr.fedorainfracloud.org/api_3/build/list?ownername=secureblue&projectname=packages&packagename=${NAME}&status=succeeded" \
+    | jq -cr '.items[0:50][] | "* \(.submitted_on | strftime("%a %b %d %Y")) secureblue <noreply@secureblue.dev> - \(.source_package.version)"' \
+    >> "${NAME}.spec"

--- a/trivalent-subresource-filter.spec
+++ b/trivalent-subresource-filter.spec
@@ -158,3 +158,6 @@ chmod a+r $INSTALL_DIR/%{chromium_name}-blocklist-version.txt
 %{_sysconfdir}/%{chromium_name}/filter/%{chromium_name}-blocklist
 %{_sysconfdir}/%{chromium_name}/filter/%{chromium_name}-blocklist-version.txt
 %{_libdir}/%{chromium_name}/install_filter.sh
+
+%changelog
+# Changelog entries automatically generated from Copr builds


### PR DESCRIPTION
Automatically generate changelog entries from the 50 most recent successful Copr builds of the package. This changelog data is used by Chunkah to estimate package stability, so adding it should result in more stable placement of this package in the layer plan.